### PR TITLE
Fix(_config.yml): Added Permalinks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,9 @@ plugins:
 include: 
   - _pages
 
+# To make endpoints for links and drop '.html' extensions
+permalink: /:title/
+
 # Defaults
 defaults:
   # _posts

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+permalink: '/'
 ---
 
 <!-- Page Header -->


### PR DESCRIPTION
## Type of PR
- [x] Bug Fix

## Description

Permalinks specify the format of the url. By specifying the permalink as title, it cleans up the url and gets rid of '.html' extensions.
Home page (having no title) had to be specified with a particular permalink '/' to override '//' conflicts.


## Related issues and discussion

Fixes #20
