### PR TITLE
Migrate from redcarpet to kramdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,7 @@ group :jekyll_plugins do
   gem "jekyll-sitemap"
 end
 
-gem "redcarpet"
-gem 'pygments.rb'
+gem "kramdown"
 gem 'jemoji'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/_config.yml
+++ b/_config.yml
@@ -16,10 +16,7 @@ google_analytics:   UA-165164055-1 # out your google-analytics code
 
 # Build settings
 future: true
-markdown: redcarpet
-highlighter: pygments
-redcarpet:
-  extensions: ["no_intra_emphasis", "fenced_code_blocks", "autolink", "strikethrough", "superscript"]
+markdown: kramdown
 
 paginate:           5
 paginate_path:      "/posts/page:num/"


### PR DESCRIPTION
## Type of PR- [ ] Blog/Article

- [ ] Feature/Enhancement
- [x] Bug Fix

## Description

I removed the redcarpet and its extensions and the highlighter also. 
I think many of them come itself with kramdown.
I have checked, and found that with extensions and higlighter, it caused problems. However after removing them, it got well.
1. Replace redcarpet with kramdown
2. Remove extensions of redcarpet.
3. Remove highlighter. 

## Related issues and discussion

Fixes #7 #8 

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] If you have multiple commits please combine them into one commit by squashing them.

- [x] Read and understood the contribution guidelines at `devbae-blog/.github/CONTRIBUTING.md`.
