### PR TITLE
mobile: Fix the social share over-width for mobile devices

### DIFF
--- a/assets/custom/scss/_social-share.scss
+++ b/assets/custom/scss/_social-share.scss
@@ -16,3 +16,10 @@
 //   font-size: $type-size-6;
 //   text-transform: uppercase;
 // }
+
+@media(max-width: 768px) {
+  .page__share {
+    display: block;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## Type of PR

- [ ] Blog/Article
- [ ] Feature/Enhancement
- [x] Bug Fix

## Description
Text align center for mobile devices.
Remove display: flex as that cause force row.

## Related issues and discussion
Fixes #49 

## Screenshots, if any

### Before:
![image](https://user-images.githubusercontent.com/56730716/119128396-3dfd6280-ba53-11eb-878c-5e8561eaeceb.png)

### After:
![image](https://user-images.githubusercontent.com/56730716/119128321-24f4b180-ba53-11eb-897a-02efae94629d.png)



## Checklist
Ha ha pata hai :p

@aashish-ak review this one as you get time.
